### PR TITLE
Bump v0.1.2 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "sleeping-policy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "jmespath",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sleeping-policy"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Bump v0.1.2 policy version.        

Updates files bumping the policy version to v0.1.2

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
