### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false
 
@@ -25,7 +25,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/policies/sleeping-policy
       artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false

--- a/metadata.yml
+++ b/metadata.yml
@@ -13,6 +13,7 @@ executionMode: kubewarden-wapc
 backgroundAudit: false
 annotations:
   io.kubewarden.policy.title: sleeping-policy
+  io.kubewarden.policy.version: 0.1.2
   io.kubewarden.policy.description: Testing policy, not meant to be used by regular
     users
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
Co-authored-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
